### PR TITLE
🔧 Add a dummy server_app to pass the validation.

### DIFF
--- a/server/fl_client_templates/pyproject.toml
+++ b/server/fl_client_templates/pyproject.toml
@@ -30,6 +30,7 @@ publisher = "Jinhyeok"
 # Format: "<module>:<object>"
 [tool.flwr.app.components]
 clientapp = "client_app:app"
+serverapp = "server_app:app"
 
 # Custom config values accessible via `context.run_config`
 [tool.flwr.app.config]

--- a/server/fl_client_templates/server_app.py
+++ b/server/fl_client_templates/server_app.py
@@ -1,0 +1,12 @@
+# server_app.py
+import flwr as fl
+app = fl.server.ServerApp()
+
+# remote-federation에선 이 함수가 호출되지 않습니다.
+@app.server_fn
+def server_fn(ctx: fl.common.Context):
+    # 호출되지 않지만, 형식만 맞춰 둡니다.
+    return fl.server.ServerAppComponents(
+        strategy=fl.server.strategy.FedAvg(),
+        config=fl.server.ServerConfig(num_rounds=1),
+    )


### PR DESCRIPTION
## 문제 상황

연합학습 참여자에서 연합학습 실행 시, client_app만 필요할 것이라고 판단하였으나, `flwr run .` 명령어 실행 시, **server_app이 존재하지 않아, validation을 통과하지 못하여 실행이 실패**하는 것을 확인하였습니다.

## 해결 방안
local simulation이 아닌, remote federation 모드로 동작하여 실제로는 server_app이 필요하지 않지만, validation을 통과하기 위해 **dummy server_app을 추가**하였습니다.

## 결과
연합학습 참여자에서 정상적으로 `flwr run .` 명령어가 동작하는 것을 확인하였습니다.